### PR TITLE
Fix issues caused by missing null terminator in property_getTypeName

### DIFF
--- a/Jastor/Jastor/JastorRuntimeHelper.m
+++ b/Jastor/Jastor/JastorRuntimeHelper.m
@@ -8,7 +8,9 @@ static const char *property_getTypeName(objc_property_t property) {
 	char *state = buffer, *attribute;
 	while ((attribute = strsep(&state, ",")) != NULL) {
 		if (attribute[0] == 'T') {
-			return (const char *)[[NSData dataWithBytes:(attribute + 3) length:strlen(attribute) - 4] bytes];
+			size_t len = strlen(attribute);
+			attribute[len - 1] = '\0';
+			return (const char *)[[NSData dataWithBytes:(attribute + 3) length:len - 2] bytes];
 		}
 	}
 	return "@";


### PR DESCRIPTION
property_getTypeName in JastorRuntimeHelper.m creates a NSData object from a character buffer, but that buffer was not null-terminated. This caused the subsequent NSString::stringWithUTF8String to sometimes fail, which resulted in uninitialized objects, or worse.

Strangely, it failed only if the property name was 16 characters long; probably some memory alignment luck saved it in other cases.
